### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/example-dotnet/example-dotnet.csproj
+++ b/example-dotnet/example-dotnet.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BCrypt.Net-Core" Version="1.2.0-CI00005" />
-    <PackageReference Include="DotNetZip" Version="1.10.0" />
+    <PackageReference Include="BCrypt.Net-Core" Version="1.3.0" />
+    <PackageReference Include="DotNetZip" Version="1.11.0" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="GSF.Security" Version="2.1.326-beta" />
-    <PackageReference Include="recurly-api-client" Version="1.8.0" />
-    <PackageReference Include="SharpCompress" Version="0.17.1" />
-    <PackageReference Include="SharpZipLib" Version="1.0.0-alpha1" />
+    <PackageReference Include="recurly-api-client" Version="1.11.4" />
+    <PackageReference Include="SharpCompress" Version="0.29.0" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
-    <PackageReference Include="YamlDotNet" Version="3.7.0" />
+    <PackageReference Include="YamlDotNet" Version="3.8.0-pre138" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MSBUILD | `dotnetzip` | 1.10.0 | 1.11.0 | Yes |
| MSBUILD | `recurly-api-client` | 1.8.0 | 1.11.4 | No |
| MSBUILD | `yamldotnet` | 3.7.0 | 3.8.0-pre138 | No |
| MSBUILD | `sharpcompress` | 0.17.1 | 0.29.0 | Yes |
| MSBUILD | `newtonsoft.json` | 11.0.2 | 13.0.1 | Yes |
| MSBUILD | `bcrypt.net-core` | 1.2.0-CI00005 | 1.3.0 | Yes |
| MSBUILD | `sharpziplib` | 1.0.0-alpha1 | 1.3.3 | Yes |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/wddUMw0e/scans/77527678).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-3e811621d53648555475933a99aa8356d0820fbffb8c623e08f5b873f04a391b -->
